### PR TITLE
Animated Page Load

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <link rel="stylesheet" href="styles/styles.css">
     </head>
     <body>
+      <div id="content-wrapper">
         <div class='container'>
             <div class='jumbotron' id='weather-condition'>
             </div>
@@ -41,6 +42,7 @@
                 </div>
             </div>
         </div>
+      </div>
         <script type='text/javascript' src='main.js'></script>
     </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -264,9 +264,9 @@ function setColor(apiData) {
        now.getMinutes() > sunset.getMinutes() ||
        now.getHours() === sunrise.getHours() &&
        now.getMinutes() < sunrise.getMinutes()) {
-       var pageBody = document.body
-       pageBody.style.backgroundColor = "black"
-       pageBody.style.color = "rgba(255, 255, 255, .85)"
+       var contentWrapper = document.getElementById("content-wrapper");
+       contentWrapper.style.backgroundColor = "black"
+       contentWrapper.style.color = "rgba(255, 255, 255, .85)"
        var jumbotron = document.getElementById('weather-condition')
        jumbotron.style.backgroundColor = "rgba(255, 255, 255, .3)"
     }
@@ -301,7 +301,7 @@ function geolocationSuccess(pos) {
           loadImage();
           setColor(weatherData);
           // Once everything is properly loaded fade-in body
-          document.body.style.opacity = 1;
+          document.getElementById("content-wrapper").style.opacity = 1;
       }
   };
 }

--- a/main.js
+++ b/main.js
@@ -300,6 +300,8 @@ function geolocationSuccess(pos) {
           loadDataTable();
           loadImage();
           setColor(weatherData);
+          // Once everything is properly loaded fade-in body
+          document.body.style.opacity = 1;
       }
   };
 }

--- a/main.js
+++ b/main.js
@@ -302,6 +302,9 @@ function geolocationSuccess(pos) {
           setColor(weatherData);
           // Once everything is properly loaded fade-in body
           document.getElementById("content-wrapper").style.opacity = 1;
+          // Remove canvas element from DOM
+          var canvas = document.querySelector("canvas");
+          document.body.removeChild(canvas);
       }
   };
 }
@@ -312,6 +315,92 @@ function geolocationError(err) {
 }
 
 window.onload = function() {
+  initAnimation();
   // Geolocation
   navigator.geolocation.getCurrentPosition(geolocationSuccess, geolocationError, {timeout: 20000});
 };
+
+
+// Animation Code below
+function initAnimation() {
+  var canvas = document.createElement("canvas");
+  canvas.width = 300;
+  canvas.height = 200;
+  canvas.style.display = "block";
+  canvas.style.margin = "100px auto";
+  canvas.style.Zindex = 50;
+  var ctx = canvas.getContext("2d");
+  var wrapper = document.getElementById("content-wrapper");
+  document.body.insertBefore(canvas, wrapper);
+  var centerX = canvas.width/2;
+  var centerY = canvas.height/2;
+
+  function drawCloudStroke(x, y, size, color) {
+   ctx.save();
+   ctx.beginPath();
+   ctx.moveTo((x-30+size*1.2), y-40);
+   ctx.arc(x-30, y-40, size*1.2, 0, Math.PI*2);
+   ctx.moveTo((x+60+size), y+10);
+   ctx.arc(x+60, y+10, size, 0, Math.PI*2);
+   ctx.moveTo((x-60+size), y+10);
+   ctx.arc(x-60, y+10, size, 0, Math.PI*2);
+   ctx.moveTo((x+size), y+10);
+   ctx.arc(x, y+10, size, 0, Math.PI*2);
+   ctx.moveTo((x+30+size), y-35);
+   ctx.arc(x+30, y-35, size, 0, Math.PI*2);
+   ctx.lineWidth = 30;
+   ctx.strokeStyle = "rgb(51, 51, 51)";
+   ctx.stroke();
+   ctx.globalCompositeOperation = "destination-out";
+   ctx.fill();
+   ctx.restore();
+  }
+
+  function drawCloudMask(x, y, size) {
+   ctx.save();
+   ctx.beginPath();
+   ctx.moveTo((x-30+size*1.2), y-40);//
+   ctx.arc(x-30, y-40, size*1.2, 0, Math.PI*2);
+   ctx.moveTo((x+60+size), y+10);//
+   ctx.arc(x+60, y+10, size, 0, Math.PI*2);
+   ctx.moveTo((x-60+size), y+10);//
+   ctx.arc(x-60, y+10, size, 0, Math.PI*2);
+   ctx.moveTo((x+size), y+10);//
+   ctx.arc(x, y+10, size, 0, Math.PI*2);
+   ctx.moveTo((x+30+size), y-35);//
+   ctx.arc(x+30, y-35, size, 0, Math.PI*2);
+   ctx.clip();
+   fillMask();
+   ctx.restore();
+  }
+
+  var fullMask = centerY-425;
+  var currentFill = centerY+180;
+
+  function fillMask() {
+   ctx.fillStyle="rgba(51, 51, 51, 0.7)"
+   ctx.fillRect(centerX-200, currentFill, 500, 300);
+  }
+
+  function loadAnimation() {
+   // Define requestAnimationFrame w/ vendor prefixes
+   var requestAnimationFrame = window.requestAnimationFrame ||
+                               window.webkitRequestAnimationFrame ||
+                               window.mozRequestAnimationFrame ||
+                               window.mozRequestAnimationFrame;
+   // Animate fill color change
+   if (currentFill > fullMask) {
+    currentFill -= 2;
+   } else {
+    currentFill = centerY+180;
+   }
+   ctx.clearRect(0, 0, canvas.width, canvas.height);
+   ctx.save();
+   drawCloudStroke(centerX, centerY+15, 34);
+   drawCloudMask(centerX, centerY+15, 35);
+   ctx.restore();
+   requestAnimationFrame(loadAnimation);
+  }
+
+  loadAnimation();
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -39,6 +39,7 @@
 @media (max-width: 1200px) {
     #weather-condition {
         margin-bottom: 0px;
+        border-radius: 0;
     }
     .container {
         width: 100%;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,3 +1,13 @@
+/* body tag starts off hidden */
+body {
+  opacity: 0;
+  /* Set transition when opacity changes */
+  -webkit-transition: opacity ease 0.8s;
+  -moz-transition: opacity ease 0.8s;
+  -o-transition: opacity ease 0.8s;
+  transition: opacity ease 0.8s;
+}
+
 #condition-picture {
     width: 90%;
     margin: 20px auto;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,11 +1,12 @@
 /* body tag starts off hidden */
-body {
-  opacity: 0;
+#content-wrapper {
+  overflow-x: hidden;
   /* Set transition when opacity changes */
-  -webkit-transition: opacity ease 0.8s;
-  -moz-transition: opacity ease 0.8s;
-  -o-transition: opacity ease 0.8s;
-  transition: opacity ease 0.8s;
+  -webkit-transition: opacity ease 1s;
+  -moz-transition: opacity ease 1s;
+  -o-transition: opacity ease 1s;
+  transition: opacity ease 1s;
+  opacity: 0;
 }
 
 #condition-picture {


### PR DESCRIPTION
Yo brotha,

So I was doodling around and thought I'd add an animated cloud that loops until the page loads, at which point the animation is removed from the DOM and the content is faded in properly. Don't worry about things like backward-compatibility, all necessary vendor prefixes are already placed within the code. 

Also tweaked a couple of style points, like the horizontal scrollbar (due to content overflow) and removing rounded corners where content should be flush (it created small gaps when content snapped to 1200px media-query). Really just tightened up loose parts of the layout, nothing too major.

When/If we end up implementing these changes, the _fadein-body_ branch will have to be merged into master branch. 

Let me know what you think,

Ian
